### PR TITLE
feature: add /boot space check before committing kernel files

### DIFF
--- a/scripts/vtbuild
+++ b/scripts/vtbuild
@@ -29,7 +29,7 @@ get_kver "${1}"
 
 # it is better to regenerate the initramfs every time
 if [ ! -f "/boot/initrd.img-${kver}" ]; then
-  
+
   touch /boot/norebuild # prevents initramfs from running vtbuild again
 
   if [ "$2" == "noinitgen" ]; then
@@ -38,16 +38,24 @@ if [ ! -f "/boot/initrd.img-${kver}" ]; then
   fi
 
   echo "initrd.img-${kver} seems to be missing, trying to generate one for you."
-  update-initramfs -c -k "${kver}"
+
+  INITRD_TMP="/tmp/vt-initrd-${kver}"
+  mkdir -p "${INITRD_TMP}"
+  update-initramfs -c -k "${kver}" -b "${INITRD_TMP}"
 
   rm -f /boot/norebuild 2> /dev/null
-fi
 
-if [ ! -f "/boot/initrd.img-${kver}" ]; then
-  echo "Sorry. I was unable to generate an initramfs. TwT"
-  exit 1
-fi
+  if [ ! -f "${INITRD_TMP}/initrd.img-${kver}" ]; then
+    echo "Sorry, I was unable to generate an initramfs."
+    rm -rf "${INITRD_TMP}"
+    exit 1
+  fi
 
+  check_boot_space "${INITRD_TMP}/initrd.img-${kver}"
+  mv "${INITRD_TMP}/initrd.img-${kver}" /boot/initrd.img-${kver}
+  rm -rf "${INITRD_TMP}"
+
+fi
 
 # fallback to generated/old cmdline
 if [[ ! -f /boot/cmdline-custom ]] && [[ ! -f "/boot/cmdline-${kver}" ]]; then

--- a/scripts/vtcommon
+++ b/scripts/vtcommon
@@ -99,3 +99,18 @@ hash_file(){
     FILE=$1
     md5sum $FILE | cut -c -32 -n
 }
+
+check_boot_space(){
+    local file=$1
+    local required=$(du -sb "$file" | cut -f1)
+    local available=$(df -B1 /boot | awk 'NR==2 {print $4}')
+
+    if [ "$available" -lt "$required" ]; then
+        echo "insufficient space on /boot to finalize kernel install."
+        echo "  required : ${required} bytes"
+        echo "  available: ${available} bytes"
+        echo "the build is preserved at: $(dirname $file)"
+        echo "free up space with vtremove and move it manually, or rebuild once space is available."
+        exit 1
+    fi
+}


### PR DESCRIPTION
i am sure there are cases i do not understand, but this is a first pass at moving building things to /tmp and testing space considerations on /boot with information to the user on why